### PR TITLE
Tallwave Colors

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1190,7 +1190,7 @@ export const totalPointsFromMilestoneMap = (milestoneMap: MilestoneMap): number 
 
 export const categoryColorScale = d3.scaleOrdinal()
   .domain(categoryIds)
-  .range(['#00abc2', '#428af6', '#e1439f', '#e54552'])
+  .range(['#fffa73', '#30bdf8', '#5d616f', '#f75757'])
 
 export const titles = [
   {label: 'Software Developer', minPoints: 0, maxPoints: 35},


### PR DESCRIPTION
This changes the color scheme to the standard Tallwave ones (#5). I did lighten up the navy color 20% because it was too dark to read the black text on top of it.

Here's what it looks like:

<img width="1078" alt="screen shot 2018-09-28 at 12 44 27 pm" src="https://user-images.githubusercontent.com/23017/46230180-a20c0f00-c31c-11e8-927a-1b6db4cfac0f.png">
